### PR TITLE
Fix bugs and limitations in NTFS utilities encountered with deep paths (over 20 levels)

### DIFF
--- a/ntfsprogs/ntfscluster.c
+++ b/ntfsprogs/ntfscluster.c
@@ -392,9 +392,8 @@ static int dump_file(ntfs_volume *vol, ntfs_inode *ino)
 	int i;
 	runlist *runs;
 
-	utils_inode_get_name(ino, buffer, sizeof(buffer));
-
-	ntfs_log_info("Dump: %s\n", buffer);
+	if (utils_inode_get_name(ino, buffer, sizeof(buffer)))
+		ntfs_log_info("Dump: %s\n", buffer);
 
 	ctx = ntfs_attr_get_search_ctx(ino, NULL);
 
@@ -440,8 +439,8 @@ static int print_match(ntfs_inode *ino, ATTR_RECORD *attr,
 		return 1;
 	}
 
-	utils_inode_get_name(ino, buffer, MAX_PATH);
-	ntfs_log_info("Inode %llu %s", (unsigned long long)ino->mft_no, buffer);
+	if (utils_inode_get_name(ino, buffer, MAX_PATH))
+		ntfs_log_info("Inode %llu %s", (unsigned long long)ino->mft_no, buffer);
 
 	utils_attr_get_name(ino->vol, attr, buffer, MAX_PATH);
 	ntfs_log_info("/%s\n", buffer);

--- a/ntfsprogs/ntfsmove.c
+++ b/ntfsprogs/ntfsmove.c
@@ -816,7 +816,8 @@ static s64 move_file(ntfs_volume *vol, ntfs_inode *ino, u64 loc, int flags)
 		return -1;
 	}
 
-	utils_inode_get_name(ino, buffer, MAX_PATH);
+	if (!utils_inode_get_name(ino, buffer, MAX_PATH))
+		return -1;
 
 	if (dont_move(ino)) {
 		ntfs_log_error("can't move\n");


### PR DESCRIPTION
This affects ntfscluster and ntfsmove.

* Don't output the path if utils_inode_get_name() returns an error, which
  previously would output an uninitialized string for deep paths, producing
  random garbage.

* If the path depth limit is encountered, utils_inode_get_name() now returns
  a partial path beginning with ".../" instead of an error code.

* Increase utils_inode_get_name()'s path depth limit from 20 to 40.

* Always free temporary memory, previously lost for deep paths.

Arguably, there shouldn't be a small fixed depth limit, but another means of loop detection, but I'm not inclined to fix and test this properly.