### PR TITLE
Halt mounting with a faulty usermapping path

### DIFF
--- a/src/ntfs-3g.c
+++ b/src/ntfs-3g.c
@@ -4514,6 +4514,16 @@ int main(int argc, char *argv[])
 #endif /* POSIXACLS */
 		ctx->dmask = ctx->fmask = 0;
 	} else {
+		/*
+		 * User mapping path was defined, but building it failed
+		 * Warn the user and halt the mounting
+		 */
+		if (ctx->usermap_path) {
+			ntfs_log_perror("Failed to load user mapping '%s'",
+					ctx->usermap_path);
+			err = NTFS_VOLUME_SYNTAX_ERROR;
+			goto err_out;
+		}
 		ctx->security.uid = ctx->uid;
 		ctx->security.gid = ctx->gid;
 		/* same ownership/permissions for all files */
@@ -4535,8 +4545,6 @@ int main(int argc, char *argv[])
 			permissions_mode = "Ownership and permissions disabled";
 		}
 	}
-	if (ctx->usermap_path)
-		free (ctx->usermap_path);
 
 #if defined(HAVE_SETXATTR) && defined(XATTR_MAPPINGS)
 	xattr_mapping = ntfs_xattr_build_mapping(ctx->vol,
@@ -4584,6 +4592,8 @@ int main(int argc, char *argv[])
 	fuse_destroy(fh);
 err_out:
 	ntfs_mount_error(opts.device, opts.mnt_point, err);
+	if (ctx->usermap_path)
+		free(ctx->usermap_path);
 	if (ctx->abs_mnt_point)
 		free(ctx->abs_mnt_point);
 #if defined(HAVE_SETXATTR) && defined(XATTR_MAPPINGS)


### PR DESCRIPTION
The driver mounts the volume with global permissions in case a
usermapping file was given but opening or reading it had failed.
The driver did not even warn about this behaviour.
This could lead into potential security related problems when
every user has full permissions in the mounted volume.