### PR TITLE
Clarify license of boot.c to be public domain and not GPL-3

### DIFF
--- a/ntfsprogs/boot.c
+++ b/ntfsprogs/boot.c
@@ -11,19 +11,7 @@
  * Copyright (C) 2008-2014 Daniel Baumann <mail@daniel-baumann.ch>
  * Copyright (C) 2015 Andreas Bombe <aeb@debian.org>
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- * The complete text of the GNU General Public License
- * can be found in /usr/share/common-licenses/GPL-3 file.
+ * The "boot code" is in the public domain.
  */
 
 #include "boot.h"
@@ -31,7 +19,7 @@
 #define BOOTCODE_SIZE 4136
 
 /* The "boot code" we put into the filesystem... it writes a message and
- * tells the user to try again */
+   tells the user to try again. This "boot code" is in the public domain. */
 
 #define MSG_OFFSET_OFFSET 3
 


### PR DESCRIPTION
The licensing of boot.c currently makes `mkntfs` special as it's the only
tool which is subject to the GPL-3 terms.

However, the only GPL-3 bits originally come from a section of the
[dosfstools](https://github.com/dosfstools/dosfstools/) `mkfs.fat.c` that has been later clarified to be under
public domain:

https://github.com/dosfstools/dosfstools/commit/3ce32fa90d1d97aa7070dad3e98db4a8b8b07fc3

Reflect this in the ntfs-3g version as well, to let people who have
issues (for whatever reason) with the GPL-3 to use ntfs-3g without
any concern.