### PR TITLE
Minor autoconf improvements for portability

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -185,6 +185,30 @@ AC_ARG_ENABLE(
 	]
 )
 
+AC_ARG_WITH(
+	[mount-helper],
+	[AS_HELP_STRING([--with-mount-helper=BIN],[use the specified binary as mount helper @<:@default=/sbin/mount@:>@])],
+	[mount_helper="$withval"],
+	[mount_helper="/sbin/mount"]
+)
+AC_DEFINE_UNQUOTED([MOUNT_HELPER], ["$mount_helper"], [Binary used as mount helper.])
+
+AC_ARG_WITH(
+	[umount-helper],
+	[AS_HELP_STRING([--with-umount-helper=BIN],[use the specified binary as umount helper @<:@default=/sbin/umount@:>@])],
+	[umount_helper="$withval"],
+	[umount_helper="/sbin/umount"]
+)
+AC_DEFINE_UNQUOTED([UMOUNT_HELPER], ["$umount_helper"], [Binary used as umount helper.])
+
+AC_ARG_WITH(
+	[modprobe-helper],
+	[AS_HELP_STRING([--with-modprobe-helper=BIN],[use the specified binary as modprobe helper @<:@default=/sbin/modprobe@:>@])],
+	[modprobe_helper="$withval"],
+	[modprobe_helper="/sbin/modprobe"]
+)
+AC_DEFINE_UNQUOTED([MODPROBE_HELPER], ["$modprobe_helper"], [Binary used as modprobe helper.])
+
 # pthread_rwlock_t requires _GNU_SOURCE
 AC_GNU_SOURCE
 

--- a/libfuse-lite/mount_util.c
+++ b/libfuse-lite/mount_util.c
@@ -89,10 +89,10 @@ int fuse_mnt_add_mount(const char *progname, const char *fsname,
             exit(1);
         }
         rmdir(tmp);
-        execle("/sbin/mount", "/sbin/mount", "-F", type, "-o", opts,
+        execle(MOUNT_HELPER, MOUNT_HELPER, "-F", type, "-o", opts,
               fsname, mnt, NULL, &env);
-        fprintf(stderr, "%s: failed to execute /sbin/mount: %s\n", progname,
-                strerror(errno));
+        fprintf(stderr, "%s: failed to execute %s: %s\n", progname,
+                MOUNT_HELPER, strerror(errno));
         exit(1);
     }
     res = waitpid(res, &status, 0);
@@ -126,14 +126,14 @@ int fuse_mnt_umount(const char *progname, const char *mnt, int lazy)
 
         setuid(geteuid());
         if (lazy) {
-            execle("/sbin/umount", "/sbin/umount", mnt,
+            execle(UMOUNT_HELPER, UMOUNT_HELPER, mnt,
                    NULL, &env);
         } else {
-            execle("/sbin/umount", "/sbin/umount", "-f", mnt,
+            execle(UMOUNT_HELPER, UMOUNT_HELPER, "-f", mnt,
                    NULL, &env);
         }
-        fprintf(stderr, "%s: failed to execute /sbin/umount: %s\n", progname,
-                strerror(errno));
+        fprintf(stderr, "%s: failed to execute %s: %s\n", progname,
+                UMOUNT_HELPER, strerror(errno));
         exit(1);
     }
     res = waitpid(res, &status, 0);

--- a/ntfsprogs/Makefile.am
+++ b/ntfsprogs/Makefile.am
@@ -165,7 +165,7 @@ extras:	libs $(EXTRA_PROGRAMS)
 
 if ENABLE_MOUNT_HELPER
 install-exec-hook:
-	$(INSTALL) -d $(DESTDIR)/$(sbindir)
+	$(INSTALL) -d $(DESTDIR)$(sbindir)
 	$(LN_S) -f $(sbindir)/mkntfs $(DESTDIR)$(sbindir)/mkfs.ntfs
 
 install-data-hook:
@@ -173,7 +173,7 @@ install-data-hook:
 	$(LN_S) -f mkntfs.8 $(DESTDIR)$(man8dir)/mkfs.ntfs.8
 
 uninstall-local:
-	$(RM) -f $(DESTDIR)/sbin/mkfs.ntfs
+	$(RM) -f $(DESTDIR)$(sbindir)/mkfs.ntfs
 	$(RM) -f $(DESTDIR)$(man8dir)/mkfs.ntfs.8
 endif
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -66,9 +66,9 @@ endif
 
 if ENABLE_MOUNT_HELPER
 install-exec-local:	install-rootbinPROGRAMS
-	$(MKDIR_P) "$(DESTDIR)/sbin"
-	$(LN_S) -f "$(rootbindir)/ntfs-3g" "$(DESTDIR)/sbin/mount.ntfs-3g"
-	$(LN_S) -f "$(rootbindir)/lowntfs-3g" "$(DESTDIR)/sbin/mount.lowntfs-3g"
+	$(MKDIR_P) "$(DESTDIR)$(rootsbindir)"
+	$(LN_S) -f "$(rootbindir)/ntfs-3g" "$(DESTDIR)$(rootsbindir)/mount.ntfs-3g"
+	$(LN_S) -f "$(rootbindir)/lowntfs-3g" "$(DESTDIR)$(rootsbindir)/mount.lowntfs-3g"
 
 install-data-local:	install-man8
 	$(LN_S) -f ntfs-3g.8 "$(DESTDIR)$(man8dir)/mount.ntfs-3g.8"
@@ -76,7 +76,7 @@ install-data-local:	install-man8
 
 uninstall-local:
 	$(RM) -f "$(DESTDIR)$(man8dir)/mount.ntfs-3g.8"
-	$(RM) -f "$(DESTDIR)/sbin/mount.ntfs-3g" "$(DESTDIR)/sbin/mount.lowntfs-3g"
+	$(RM) -f "$(DESTDIR)$(rootsbindir)/mount.ntfs-3g" "$(DESTDIR)$(rootsbindir)/mount.lowntfs-3g"
 endif
 
 endif # ENABLE_NTFS_3G

--- a/src/lowntfs-3g.c
+++ b/src/lowntfs-3g.c
@@ -4463,7 +4463,7 @@ static fuse_fstype load_fuse_module(void)
 	int i;
 	struct stat st;
 	pid_t pid;
-	const char *cmd = "/sbin/modprobe";
+	const char *cmd = MODPROBE_HELPER;
 	char *env = (char*)NULL;
 	struct timespec req = { 0, 100000000 };   /* 100 msec */
 	fuse_fstype fstype;

--- a/src/ntfs-3g.c
+++ b/src/ntfs-3g.c
@@ -4171,7 +4171,7 @@ static fuse_fstype load_fuse_module(void)
 	int i;
 	struct stat st;
 	pid_t pid;
-	const char *cmd = "/sbin/modprobe";
+	const char *cmd = MODPROBE_HELPER;
 	char *env = (char*)NULL;
 	struct timespec req = { 0, 100000000 };   /* 100 msec */
 	fuse_fstype fstype;


### PR DESCRIPTION
These two commits improve the portability of ntfs-3g on systems that do not use the standard Linux FHS (e.g. NixOS, Gobo, GuixSD, etc.).

- The first commit is a bugfix: ntfs-3g already uses rootsbindir/sbindir in most places but not everywhere.
- The second commit is a set of new configuration options for specifying the paths to `/sbin` helpers used at runtime by the ntfs-3g programs.