### PR TITLE
Improve ntfs_device_size_get for file

### DIFF
--- a/libntfs-3g/device.c
+++ b/libntfs-3g/device.c
@@ -601,7 +601,7 @@ s64 ntfs_device_size_get(struct ntfs_device *dev, int block_size)
 	 * We couldn't figure it out by using a specialized ioctl,
 	 * so do lstat on device.
 	 */
-	if (dev->d_ops->stat(dev, &sbuf) == 0) {
+	if (dev->d_ops->stat(dev, &sbuf) == 0 && S_ISREG(sbuf.st_mode)) {
 		ntfs_log_debug("STAT nr bytes = %llu (0x%llx)\n",
 			(unsigned long long)sbuf.st_size,
 			(unsigned long long)sbuf.st_size);

--- a/libntfs-3g/device.c
+++ b/libntfs-3g/device.c
@@ -601,7 +601,7 @@ s64 ntfs_device_size_get(struct ntfs_device *dev, int block_size)
 	 * We couldn't figure it out by using a specialized ioctl,
 	 * so do lstat on device.
 	 */
-	if (dev->d_ops->stat(dev, &sbuf) == 0 && S_ISREG(sbuf.st_mode)) {
+	if (dev->d_ops->stat(dev, &sbuf) == 0 && S_ISREG(sbuf.st_mode) && sbuf.st_size > 512) {
 		ntfs_log_debug("STAT nr bytes = %llu (0x%llx)\n",
 			(unsigned long long)sbuf.st_size,
 			(unsigned long long)sbuf.st_size);


### PR DESCRIPTION
For avoid random read we can use IO callback for get size from **struct stat**.
Issue: https://github.com/tuxera/ntfs-3g/issues/46