### PR TITLE
Add autogen.sh invocation to readme

### DIFF
--- a/README
+++ b/README
@@ -52,9 +52,10 @@ the recommended way is to install it.
 
 If you need some specific customization, you can compile and install from
 the released source code. Make sure you have the basic development tools
-and the kernel includes the FUSE kernel module. Then unpack the source
-tarball and type:  
+and the kernel includes the FUSE kernel module. Download and unpack the
+release tarball or clone the repository and type:
 
+	./autogen.sh      # Only when building from a cloned repository
 	./configure
 	make
 	make install      # or 'sudo make install' if you aren't root.


### PR DESCRIPTION
It is a required build step to run ./autogen.sh, as it generates ./configure,
which in turn generates the Makefile.
The readme did not reflect this.