### PR TITLE
configure.ac: fix bashism in fuse check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -228,7 +228,7 @@ esac
 
 if test "x${enable_ntfs_3g}" != "xyes"; then
 	with_fuse="none"
-elif test "x${with_fuse}" == "x"; then
+elif test "x${with_fuse}" = "x"; then
 	AC_MSG_CHECKING([fuse compatibility])
 	case "${target_os}" in
 	linux*|solaris*)


### PR DESCRIPTION
configure scripts need to be runnable with a POSIX-compliant /bin/sh.

On many (but not all!) systems, /bin/sh is provided by Bash, so errors like this aren't spotted. Notably Debian defaults to /bin/sh provided by dash which doesn't tolerate such bashisms as '=='.

This retains compatibility with bash.

Fixes configure warnings/errors like:
```
checking Windows OS... no
./configure: 13360: test: xinternal: unexpected operator
checking for pthread_create in -lpthread... yes
checking Solaris OS... no
```

Signed-off-by: Sam James <sam@gentoo.org>