### PR TITLE
minor fixes

### DIFF
--- a/include/ntfs-3g/ntfstime.h
+++ b/include/ntfs-3g/ntfstime.h
@@ -39,7 +39,7 @@
 /*
  * assume "struct timespec" is not defined if st_mtime is not defined
  */
-#if !defined(st_mtime) & !defined(__timespec_defined)
+#if !defined(st_mtime)
 struct timespec {
 	time_t tv_sec;
 	long tv_nsec;

--- a/libntfs-3g/ioctl.c
+++ b/libntfs-3g/ioctl.c
@@ -48,7 +48,9 @@
 #ifdef HAVE_LIMITS_H
 #include <limits.h>
 #endif
+#ifdef HAVE_SYSLOG_H
 #include <syslog.h>
+#endif
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif


### PR DESCRIPTION
- include/ntfs-3g/ntfstime.h: fix struct timespec check
- libntfs-3g/ioctl.c: guard use of syslog.h