### PR TITLE
Fix Cygwin build

### DIFF
--- a/README
+++ b/README
@@ -119,6 +119,30 @@ then, as root:
 And, to end the test, unmount the usual way:
 	umount /dev/sda1
 
+BUILDING FOR WINDOWS
+====================
+
+A subset of the components found in this repository may be compiled and
+executed on Windows. This includes the libntfs-3g library and the ntfsprogs
+programs, but NOT the actual ntfs-3g driver.
+
+To target Cygwin, you must install the following packages
+from the Cygwin installer:
+
+	automake
+	libtool
+	make
+	gcc-core
+	libgcrypt-devel
+
+Then
+
+	./configure --disable-ntfs-3g --disable-plugins
+	make
+
+The full set of ntfsprogs, including ntfsusermap, can be built using:
+
+	make extra
 
 NTFS UTILITIES
 ==============

--- a/include/ntfs-3g/device_io.h
+++ b/include/ntfs-3g/device_io.h
@@ -69,6 +69,9 @@ struct hd_geometry {
 /* On Windows (and Cygwin) : use Win32 low level device operations. */
 #define ntfs_device_default_io_ops ntfs_device_win32_io_ops
 
+/* Forward declaration. */
+struct ntfs_device;
+
 /* A few useful functions */
 int ntfs_win32_set_sparse(int);
 int ntfs_win32_ftruncate(int fd, s64 size);

--- a/include/ntfs-3g/ntfstime.h
+++ b/include/ntfs-3g/ntfstime.h
@@ -39,7 +39,7 @@
 /*
  * assume "struct timespec" is not defined if st_mtime is not defined
  */
-#if !defined(st_mtime) & !defined(__timespec_defined)
+#if !defined(st_mtime)
 struct timespec {
 	time_t tv_sec;
 	long tv_nsec;

--- a/libntfs-3g/Makefile.am
+++ b/libntfs-3g/Makefile.am
@@ -14,6 +14,10 @@ libntfs_3g_la_CPPFLAGS= $(AM_CPPFLAGS) $(LIBNTFS_CPPFLAGS) -I$(top_srcdir)/inclu
 libntfs_3g_la_LIBADD  = $(LIBNTFS_LIBS)
 libntfs_3g_la_LDFLAGS = -version-info $(LIBNTFS_3G_VERSION) -no-undefined
 
+if WINDOWS
+libntfs_3g_la_LDFLAGS += -lntdll
+endif
+
 libntfs_3g_la_SOURCES =	\
 	acls.c 	\
 	attrib.c 	\

--- a/libntfs-3g/ioctl.c
+++ b/libntfs-3g/ioctl.c
@@ -48,7 +48,9 @@
 #ifdef HAVE_LIMITS_H
 #include <limits.h>
 #endif
+#ifdef HAVE_SYSLOG_H
 #include <syslog.h>
+#endif
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif

--- a/libntfs-3g/win32_io.c
+++ b/libntfs-3g/win32_io.c
@@ -125,6 +125,30 @@ static LPFN_SETFILEPOINTEREX fnSetFilePointerEx = NULL;
 #define FNPOSTFIX "A"
 #endif
 
+/* 
+ * Since many of the ahead enum constants conflict with winnt.h defines,
+ * make sure that each enum constant is undefined.
+ */
+
+#undef STATUS_UNKNOWN
+#undef STATUS_SUCCESS
+#undef STATUS_BUFFER_OVERFLOW
+#undef STATUS_INVALID_HANDLE
+#undef STATUS_INVALID_PARAMETER
+#undef STATUS_INVALID_DEVICE_REQUEST
+#undef STATUS_END_OF_FILE
+#undef STATUS_CONFLICTING_ADDRESSES
+#undef STATUS_NO_MATCH
+#undef STATUS_ACCESS_DENIED
+#undef STATUS_BUFFER_TOO_SMALL
+#undef STATUS_OBJECT_TYPE_MISMATCH
+#undef STATUS_FILE_NOT_FOUND
+#undef STATUS_OBJECT_NAME_INVALID
+#undef STATUS_OBJECT_NAME_NOT_FOUND
+#undef STATUS_SHARING_VIOLATION
+#undef STATUS_INVALID_PARAMETER_1
+#undef STATUS_IO_DEVICE_ERROR
+#undef STATUS_GUARD_PAGE_VIOLATION
 enum { /* see http://msdn.microsoft.com/en-us/library/cc704588(v=prot.10).aspx */
    STATUS_UNKNOWN = -1,
    STATUS_SUCCESS =              0x00000000,

--- a/libntfs-3g/win32_io.c
+++ b/libntfs-3g/win32_io.c
@@ -61,7 +61,9 @@ typedef unsigned long long DWORD64;
 #endif
 #ifdef HAVE_SYS_STAT_H
 #include <sys/stat.h>
+#ifndef __CYGWIN__ /* See https://cygwin.com/faq.html#faq.programming.stat64 */
 #define stat stat64
+#endif
 #define st_blocks  st_rdev /* emulate st_blocks, missing in Windows */
 #endif
 

--- a/libntfs-3g/win32_io.c
+++ b/libntfs-3g/win32_io.c
@@ -360,7 +360,7 @@ static int ntfs_w32error_to_errno(unsigned int w32error)
 
 static int ntfs_ntstatus_to_errno(NTSTATUS status)
 {
-	ntfs_log_trace("Converting w32error 0x%x.\n",w32error);
+	ntfs_log_trace("Converting w32error 0x%x.\n",status);
 	switch (status) {
 		case STATUS_INVALID_HANDLE :
 		case STATUS_INVALID_PARAMETER :

--- a/libntfs-3g/win32_io.c
+++ b/libntfs-3g/win32_io.c
@@ -45,15 +45,6 @@
 typedef unsigned long long DWORD64;
 #endif
 
-typedef struct {
-        DWORD data1;     /* The first eight hexadecimal digits of the GUID. */
-        WORD data2;     /* The first group of four hexadecimal digits. */
-        WORD data3;     /* The second group of four hexadecimal digits. */ 
-        char data4[8];    /* The first two bytes are the third group of four
-                           hexadecimal digits. The remaining six bytes are the
-                           final 12 hexadecimal digits. */
-} GUID;
-
 #include <winioctl.h>
 
 #ifdef HAVE_STDIO_H

--- a/libntfs-3g/win32_io.c
+++ b/libntfs-3g/win32_io.c
@@ -27,9 +27,9 @@
 #include "config.h"
 
 #ifdef HAVE_WINDOWS_H
-#define BOOL WINBOOL /* avoid conflicting definitions of BOOL */
+#define _NO_BOOL_TYPEDEF /* supported by both Cygwin and MinGW-w64's w32api */ 
 #include <windows.h>
-#undef BOOL
+#undef _NO_BOOL_TYPEDEF
 #endif
 
 #ifdef HAVE_STDLIB_H

--- a/libntfs-3g/win32_io.c
+++ b/libntfs-3g/win32_io.c
@@ -180,7 +180,7 @@ typedef unsigned long long ULONG_PTR; /* an integer the same size as a pointer *
 typedef unsigned long ULONG_PTR; /* an integer the same size as a pointer */
 #endif
 
-HANDLE get_osfhandle(int); /* from msvcrt.dll */
+HANDLE _get_osfhandle(int); /* from msvcrt.dll */
 
 /*
  *		A few needed definitions not included in <windows.h>
@@ -1987,7 +1987,7 @@ int ntfs_win32_set_sparse(int fd)
 	HANDLE handle;
 	DWORD bytes;   
 
-	handle = get_osfhandle(fd);
+	handle = _get_osfhandle(fd);
 	if (handle == INVALID_HANDLE_VALUE)
 		ok = FALSE;
 	else
@@ -2051,7 +2051,7 @@ int ntfs_win32_ftruncate(int fd, s64 size)
 	int ret;
 	HANDLE handle;
 
-	handle = get_osfhandle(fd);
+	handle = _get_osfhandle(fd);
 	ret = win32_ftruncate(handle, size);
 	return (ret);
 }

--- a/libntfs-3g/win32_io.c
+++ b/libntfs-3g/win32_io.c
@@ -1340,7 +1340,8 @@ static s64 ntfs_device_win32_seek(struct ntfs_device *dev, s64 offset,
  * @fd:		win32 device descriptor obtained via ->open
  * @pos:	at which position to do i/o from/to
  * @count:	how many bytes should be transfered
- * @b:		source/destination buffer
+ * @rbuf:	source buffer (null if writing)
+ * @wbuf:	destination buffer (null if reading)
  * @write:	TRUE if write transfer and FALSE if read transfer
  *
  * On success returns the number of bytes transfered (can be < @count) and on
@@ -1362,7 +1363,7 @@ static s64 ntfs_device_win32_pio(win32_fd *fd, const s64 pos,
 	s64 bytes;
 
 	ntfs_log_trace("pos = 0x%llx, count = 0x%llx, direction = %s.\n",
-			(long long)pos, (long long)count, write ? "write" :
+			(long long)pos, (long long)count, wbuf ? "write" :
 			"read");
 	li.QuadPart = pos;
 	if (fd->vol_handle != INVALID_HANDLE_VALUE && pos < fd->geo_size) {
@@ -1412,7 +1413,7 @@ static s64 ntfs_device_win32_pio(win32_fd *fd, const s64 pos,
 		bytes = bt;
 		if (!res) {
 			errno = ntfs_w32error_to_errno(GetLastError());
-			ntfs_log_trace("%sFile() failed.\n", write ?
+			ntfs_log_trace("%sFile() failed.\n", wbuf ?
 							"Write" : "Read");
 			return -1;
 		}

--- a/libntfs-3g/win32_io.c
+++ b/libntfs-3g/win32_io.c
@@ -171,7 +171,7 @@ enum { /* see http://msdn.microsoft.com/en-us/library/cc704588(v=prot.10).aspx *
    STATUS_GUARD_PAGE_VIOLATION = 0x80000001
  } ;
 
-typedef u32 NTSTATUS; /* do not let the compiler choose the size */
+typedef s32 NTSTATUS; /* do not let the compiler choose the size */
 #ifdef __x86_64__
 typedef unsigned long long ULONG_PTR; /* an integer the same size as a pointer */
 #else

--- a/ntfsprogs/ntfsclone.c
+++ b/ntfsprogs/ntfsclone.c
@@ -110,10 +110,14 @@
 #endif
 
 #ifdef HAVE_WINDOWS_H
+#ifdef __CYGWIN__
+#include <io.h>
+#else
 /*
  *		Replacements for functions which do not exist on Windows
  */
 int setmode(int, int); /* from msvcrt.dll */
+#endif
 
 #define getpid() (0)
 #define srandom(seed) srand(seed)

--- a/ntfsprogs/ntfssecaudit.c
+++ b/ntfsprogs/ntfssecaudit.c
@@ -434,6 +434,16 @@ struct SDH {		/* this is an image of an $SDH index entry */
 	} ;
 
 #ifdef HAVE_WINDOWS_H
+
+// Copied from minwindef.h.
+#ifndef WINAPI
+#if defined(_ARM_)
+#define WINAPI
+#else
+#define WINAPI __stdcall
+#endif
+#endif
+
 /*
  *	Including <windows.h> leads to numerous conflicts with layout.h
  *	so define a few needed Windows calls unrelated to ntfs-3g

--- a/ntfsprogs/ntfsusermap.c
+++ b/ntfsprogs/ntfsusermap.c
@@ -142,6 +142,16 @@
 #include "misc.h"
 
 #ifdef HAVE_WINDOWS_H
+
+// Copied from minwindef.h.
+#ifndef WINAPI
+#if defined(_ARM_)
+#define WINAPI
+#else
+#define WINAPI __stdcall
+#endif
+#endif
+
 /*
  *	Including <windows.h> leads to numerous conflicts with layout.h
  *	so define a few needed Windows calls unrelated to ntfs-3g

--- a/ntfsprogs/ntfsusermap.c
+++ b/ntfsprogs/ntfsusermap.c
@@ -814,7 +814,12 @@ static boolean outputmap(const char *volume, const char *dir)
 			/* build directory, if not present */
 		if (stat(fullname,&st) && (errno == ENOENT)) {
 			printf("* Creating directory %s\n", fullname);
+			#ifdef __CYGWIN__
+			// The one-argument mkdir is exclusive to msvcrt.dll.
+			mkdir(fullname, 777);
+			#else
 			mkdir(fullname);
+			#endif
 		}
 
 		strcat(fullname, DIRSEP);

--- a/ntfsprogs/ntfsusermap.c
+++ b/ntfsprogs/ntfsusermap.c
@@ -816,7 +816,7 @@ static boolean outputmap(const char *volume, const char *dir)
 			printf("* Creating directory %s\n", fullname);
 			#ifdef __CYGWIN__
 			// The one-argument mkdir is exclusive to msvcrt.dll.
-			mkdir(fullname, 777);
+			mkdir(fullname, 0777);
 			#else
 			mkdir(fullname);
 			#endif

--- a/ntfsprogs/utils.h
+++ b/ntfsprogs/utils.h
@@ -101,27 +101,6 @@ int mft_next_record(struct mft_search_ctx *ctx);
 #define MAX_PATH 1024
 #endif
 
-#ifdef HAVE_WINDOWS_H
-/*
- *	Macroes to hide the needs to translate formats on older Windows
- */
-#define MAX_FMT 1536
-char *ntfs_utils_reformat(char *out, int sz, const char *fmt);
-char *ntfs_utils_unix_path(const char *in);
-#define ntfs_log_redirect(fn,fi,li,le,d,fmt, args...) \
-		do { char _b[MAX_FMT]; ntfs_log_redirect(fn,fi,li,le,d, \
-		ntfs_utils_reformat(_b,MAX_FMT,fmt), args); } while (0)
-#define printf(fmt, args...) \
-		do { char _b[MAX_FMT]; \
-		printf(ntfs_utils_reformat(_b,MAX_FMT,fmt), args); } while (0)
-#define fprintf(str, fmt, args...) \
-		do { char _b[MAX_FMT]; \
-		fprintf(str, ntfs_utils_reformat(_b,MAX_FMT,fmt), args); } while (0)
-#define vfprintf(file, fmt, args) \
-		do { char _b[MAX_FMT]; vfprintf(file, \
-		ntfs_utils_reformat(_b,MAX_FMT,fmt), args); } while (0)
-#endif
-
 /**
  * linux-ntfs's ntfs_mbstoucs has different semantics, so we emulate it with
  * ntfs-3g's.


### PR DESCRIPTION
I was interested in using ntfsusermap on Windows but the current source wouldn't build on Cygwin. After some changes I got it to work. This PR just has fixes for Cygwin; I looked into MinGW too (over at the [mingw branch](https://github.com/CodingKoopa/ntfs-3g/tree/mingw)) but it was too much work.

This PR is based on #105 (partly because I thought the timespec fix would help me). From there, each commit fixes a compiler/linker error (or set of errors). I don't really have the time or motivation to see this through to the end, so I may need to close the PR if nontrivial changes are needed. At the very least, I wanted to contribute some tips for anyone else who wanted to do the same. And, perhaps there are some fixes worth cherry-picking in isolation ^^

The changes range from well-reasoned fixes like the ntdll linking in d43ede9b7d7c5441197e4479a3fd11888c32c3af, to quick hacks like f1960238411d0a7286ed279749968398df83e10f. It's a mixed bag, sorry!