### PR TITLE
Create mkfs.ntfs as relative symlink

### DIFF
--- a/ntfsprogs/Makefile.am
+++ b/ntfsprogs/Makefile.am
@@ -181,7 +181,7 @@ extras:	libs $(EXTRA_PROGRAMS)
 if ENABLE_MOUNT_HELPER
 install-exec-hook:
 	$(INSTALL) -d $(DESTDIR)/$(sbindir)
-	$(LN_S) -f $(sbindir)/mkntfs $(DESTDIR)$(sbindir)/mkfs.ntfs
+	$(LN_S) -f mkntfs $(DESTDIR)$(sbindir)/mkfs.ntfs
 
 install-data-hook:
 	$(INSTALL) -d $(DESTDIR)$(man8dir)


### PR DESCRIPTION
Since 7bcae8743fc the link target is in the same directory as the link itself so it can be shortened to a relative link.