### PR TITLE
fix(ntfsprogs/mkntfs): use after free

### DIFF
--- a/ntfsprogs/mkntfs.c
+++ b/ntfsprogs/mkntfs.c
@@ -4683,10 +4683,10 @@ static BOOL mkntfs_create_root_structures(void)
 				1);
 		if ((u32)(1 << -bs->clusters_per_mft_record) !=
 				g_vol->mft_record_size) {
-			free(bs);
 			ntfs_log_error("BUG: calculated clusters_per_mft_record"
 					" is wrong (= 0x%x)\n",
 					bs->clusters_per_mft_record);
+			free(bs);
 			return FALSE;
 		}
 	}
@@ -4700,11 +4700,11 @@ static BOOL mkntfs_create_root_structures(void)
 		bs->clusters_per_index_record = -g_vol->indx_record_size_bits;
 		if ((1 << -bs->clusters_per_index_record) !=
 				(s32)g_vol->indx_record_size) {
-			free(bs);
 			ntfs_log_error("BUG: calculated "
 					"clusters_per_index_record is wrong "
 					"(= 0x%x)\n",
 					bs->clusters_per_index_record);
+			free(bs);
 			return FALSE;
 		}
 	}


### PR DESCRIPTION
```sh
mkntfs.c:4689:43: warning: pointer ‘bs_674’ used after ‘free’ [-Wuse-after-free]
 4689 |                                         bs->clusters_per_mft_record);
      |                                         ~~^~~~~~~~~~~~~~~~~~~~~~~~~
mkntfs.c:4686:25: note: call to ‘free’ here
 4686 |                         free(bs);
      |                         ^~~~~~~~
mkntfs.c:4707:43: warning: pointer ‘bs_674’ used after ‘free’ [-Wuse-after-free]
 4707 |                                         bs->clusters_per_index_record);
      |                                         ~~^~~~~~~~~~~~~~~~~~~~~~~~~~~
mkntfs.c:4703:25: note: call to ‘free’ here
 4703 |                         free(bs);
      |                         ^~~~~~~~
```