### PR TITLE
fix: use of uninitialized memory

### DIFF
--- a/ntfsprogs/ntfswipe.c
+++ b/ntfsprogs/ntfswipe.c
@@ -1722,7 +1722,7 @@ static int destroy_record(ntfs_volume *nv, const s64 record,
 	unsigned long int pass, i;
 	s64 j;
 	unsigned char * a_offset;
-	int selected[NPAT];
+	int selected[NPAT] = {0};
 
 	file = (struct ufile *) malloc(sizeof(struct ufile));
 	if (file == NULL) {


### PR DESCRIPTION
```c
int selected[NPAT];
[...]
fill_buffer([...], selected);
->[...]
if (pat_no % npasses == 0) [...] -> false
[...]
if (selected[i] == 0) // access to uninitialized memory!!!
```

[full compiler output](https://godbolt.org/z/f5qEP3TEj)