### PR TITLE
Fix dereference nullptr

### DIFF
--- a/ntfsprogs/cluster.c
+++ b/ntfsprogs/cluster.c
@@ -56,6 +56,10 @@ int cluster_find(ntfs_volume *vol, LCN c_begin, LCN c_end, cluster_cb *cb, void 
 		return -1;
 
 	m_ctx = mft_get_search_ctx(vol);
+
+	if (!m_ctx)
+		return -1;
+
 	m_ctx->flags_search = FEMR_IN_USE | FEMR_BASE_RECORD;
 	count = 0;
 


### PR DESCRIPTION
some code contained nullptr dereferencing

calloc (in the `mft_get_search_ctx` function) can return nullptr, then need check and return nullptr? -- then `m_ctx->flags_search` is a nullptr dereferencing.
https://github.com/tuxera/ntfs-3g/blob/75dcdc2cf37478fad6c0e3427403d198b554951d/ntfsprogs/utils.c#L977
