### PR TITLE
ntfsprogs: make mkntfs create FS on a plain file

### DIFF
--- a/ntfsprogs/mkntfs.8.in
+++ b/ntfsprogs/mkntfs.8.in
@@ -222,7 +222,7 @@ Force
 .B mkntfs
 to run, even if the specified
 .I device
-is not a block special device, or appears to be mounted.
+appears to be mounted.
 .SS Output options
 .TP
 \fB\-q\fR, \fB\-\-quiet\fR

--- a/ntfsprogs/mkntfs.c
+++ b/ntfsprogs/mkntfs.c
@@ -3503,11 +3503,6 @@ static BOOL mkntfs_open_partition(ntfs_volume *vol)
 	}
 
 	if (!S_ISBLK(sbuf.st_mode)) {
-		ntfs_log_error("%s is not a block device.\n", vol->dev->d_name);
-		if (!opts.force) {
-			ntfs_log_error("Refusing to make a filesystem here!\n");
-			goto done;
-		}
 		if (!opts.num_sectors) {
 			if (!sbuf.st_size && !sbuf.st_blocks) {
 				ntfs_log_error("You must specify the number of sectors.\n");


### PR DESCRIPTION
For testing purposes it is frequently useful to be able to format a plain file as certain file-system and then mount it. All of the standard mkfs* utilities adhere to that, like mkext*, mkexfat, etc.

Make sure mkntfs works same way too.

Fixes: https://github.com/tuxera/ntfs-3g/issues/145