### PR TITLE
ntfsprogs/mkntfs: improve error when creating NTFS on a plain file

### DIFF
--- a/ntfsprogs/mkntfs.c
+++ b/ntfsprogs/mkntfs.c
@@ -3503,7 +3503,11 @@ static BOOL mkntfs_open_partition(ntfs_volume *vol)
 	}
 
 	if (!S_ISBLK(sbuf.st_mode)) {
-		ntfs_log_error("%s is not a block device.\n", vol->dev->d_name);
+		ntfs_log_error("%s is not a block device.\n"
+                       "You can force creation with `--force`, but note that such image "
+                       "couldn't be transferred to the actual device because device and "
+                       "NTFS sector sizes must match.\n"
+                       , vol->dev->d_name);
 		if (!opts.force) {
 			ntfs_log_error("Refusing to make a filesystem here!\n");
 			goto done;


### PR DESCRIPTION
mkntfs is special among all other mkfs utilities in that it'd refuse to create an FS over a plain file (which is often needed for testing purposes). This might seem like an odd choice, but it has to do with how NTFS works, and the error is there to make sure things wouldn't go south for a user.

However, it lacked the explanation what exactly may be wrong, not to mention it also didn't mention that FS could be created by passing `--force`. Fix that.

Fixes: https://github.com/tuxera/ntfs-3g/issues/145