### PR TITLE
Fix typo in NTFS hibernation error message ("turned it off" → "turn it off")

### DIFF
--- a/ntfsprogs/utils.c
+++ b/ntfsprogs/utils.c
@@ -94,7 +94,7 @@ static const char *corrupt_volume_msg =
 "made to NTFS by this software.\n";
 
 static const char *hibernated_volume_msg =
-"The NTFS partition is hibernated. Please resume Windows and turned it \n"
+"The NTFS partition is hibernated. Please resume Windows and turn it \n"
 "off properly, so mounting could be done safely.\n";
 
 static const char *unclean_journal_msg =


### PR DESCRIPTION
This fixes a minor typo in the error message shown when attempting to mount a hibernated NTFS partition.

**Before:**
> Please resume Windows and `turned` it off properly

**After:**
> Please resume Windows and `turn` it off properly

This improves the grammar and clarity of the error output.

**Better message could be:**
> The NTFS partition is hibernated. Please resume Windows and shut it down properly so the volume can be mounted safely.