### PR TITLE
Does not access to xattrs on FreeBSD

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -537,11 +537,20 @@ AC_FUNC_UTIME_NULL
 AC_FUNC_VPRINTF
 AC_CHECK_FUNCS([ \
 	atexit basename daemon dup2 fdatasync ffs getopt_long hasmntopt \
-	mbsinit memmove memset realpath regcomp setlocale setxattr \
+	mbsinit memmove memset realpath regcomp setlocale \
 	strcasecmp strchr strdup strerror strnlen strsep strtol strtoul \
 	sysconf utime utimensat gettimeofday clock_gettime fork memcpy random snprintf \
 ])
 AC_SYS_LARGEFILE
+
+AC_CHECK_FUNCS([setxattr extattr_set_file],
+	[
+		AC_DEFINE([ENABLE_XATTR], 1,
+		[Define this to 1 if you want to enable
+		extended attributes support.])
+	],
+	[],
+)
 
 # The dlopen API might be in libc or in libdl.  Check libc first, then
 # fall back to libdl.

--- a/ntfsprogs/ntfssecaudit.c
+++ b/ntfsprogs/ntfssecaudit.c
@@ -294,7 +294,7 @@
 #endif /* HAVE_SYS_STAT_H */
 #ifdef HAVE_SETXATTR
 #include <sys/xattr.h>
-#else /* HAVE_SETXATTR */
+#elif !defined(ENABLE_XATTR)  /* HAVE_SETXATTR */
 #warning "The extended attribute package is not available"
 #endif /* HAVE_SETXATTR */
 
@@ -4371,7 +4371,7 @@ static BOOL singleshow(const char *path)
 
 #ifndef HAVE_WINDOWS_H
 
-#ifdef HAVE_SETXATTR
+#ifdef ENABLE_XATTR
 
 static ssize_t ntfs_getxattr(const char *path, const char *name, void *value, size_t size)
 {
@@ -4526,7 +4526,7 @@ static BOOL processmounted(const char *fullname)
 	return (err);
 }
 
-#else /* HAVE_SETXATTR */
+#else /* ENABLE_XATTR */
 
 static BOOL processmounted(const char *fullname __attribute__((unused)))
 {
@@ -4535,7 +4535,7 @@ static BOOL processmounted(const char *fullname __attribute__((unused)))
 	return (TRUE);
 }
 
-#endif /* HAVE_SETXATTR */
+#endif /* ENABLE_XATTR */
 
 #endif /* HAVE_WINDOWS_H */
 
@@ -6007,13 +6007,13 @@ static void usage(void)
 	fprintf(stderr,"	set the security parameters of file to perms\n");
 	fprintf(stderr,"   ntfssecaudit -r[v] volume perms directory\n");
 	fprintf(stderr,"	set the security parameters of files in directory to perms\n");
-#ifdef HAVE_SETXATTR
+#ifdef ENABLE_XATTR
 	fprintf(stderr," special cases, do not require being root :\n");
 	fprintf(stderr,"   ntfssecaudit -u mounted-file\n");
 	fprintf(stderr,"	get a user mapping proposal applicable to mounted file\n");
 	fprintf(stderr,"   ntfssecaudit [-v] mounted-file\n");
 	fprintf(stderr,"	display the security parameters of a mounted file\n");
-#endif /* HAVE_SETXATTR */
+#endif /* ENABLE_XATTR */
 #if POSIXACLS
 	fprintf(stderr,"   Notes: perms can be an octal mode or a Posix ACL description\n");
 #else /* POSIXACLS */

--- a/src/lowntfs-3g.c
+++ b/src/lowntfs-3g.c
@@ -249,7 +249,7 @@ static const char *usage_msg =
 "\n"
 "%s %s %s %d - Third Generation NTFS Driver\n"
 "\t\tConfiguration type %d, "
-#ifdef HAVE_SETXATTR
+#ifdef ENABLE_XATTR
 "XATTRS are on, "
 #else
 "XATTRS are off, "
@@ -824,7 +824,7 @@ static int ntfs_fuse_getstat(struct SECURITY_CONTEXT *scx,
 		/* Regular or Interix (INTX) file. */
 		stbuf->st_mode = S_IFREG;
 		stbuf->st_size = ni->data_size;
-#ifdef HAVE_SETXATTR	/* extended attributes interface required */
+#ifdef ENABLE_XATTR	/* extended attributes interface required */
 		/*
 		 * return data size rounded to next 512 byte boundary for
 		 * encrypted files to include padding required for decryption
@@ -834,7 +834,7 @@ static int ntfs_fuse_getstat(struct SECURITY_CONTEXT *scx,
 		    && (ni->flags & FILE_ATTR_ENCRYPTED)
 		    && ni->data_size)
 			stbuf->st_size = ((ni->data_size + 511) & ~511) + 2;
-#endif /* HAVE_SETXATTR */
+#endif /* ENABLE_XATTR */
 		/* 
 		 * Temporary fix to make ActiveSync work via Samba 3.0.
 		 * See more on the ntfs-3g-devel list.
@@ -1655,13 +1655,13 @@ static void ntfs_fuse_open(fuse_req_t req, fuse_ino_t ino,
 		/* mark a future need to compress the last chunk */
 			if (na->data_flags & ATTR_COMPRESSION_MASK)
 				state |= CLOSE_COMPRESSED;
-#ifdef HAVE_SETXATTR	/* extended attributes interface required */
+#ifdef ENABLE_XATTR	/* extended attributes interface required */
 		/* mark a future need to fixup encrypted inode */
 			if (ctx->efs_raw
 			    && !(na->data_flags & ATTR_IS_ENCRYPTED)
 			    && (ni->flags & FILE_ATTR_ENCRYPTED))
 				state |= CLOSE_ENCRYPTED;
-#endif /* HAVE_SETXATTR */
+#endif /* ENABLE_XATTR */
 		/* mark a future need to update the mtime */
 			if (ctx->dmtime)
 				state |= CLOSE_DMTIME;
@@ -1746,7 +1746,7 @@ static void ntfs_fuse_read(fuse_req_t req, fuse_ino_t ino, size_t size,
 		goto exit;
 	}
 	max_read = na->data_size;
-#ifdef HAVE_SETXATTR	/* extended attributes interface required */
+#ifdef ENABLE_XATTR	/* extended attributes interface required */
 	/* limit reads at next 512 byte boundary for encrypted attributes */
 	if (ctx->efs_raw
 	    && max_read
@@ -1754,7 +1754,7 @@ static void ntfs_fuse_read(fuse_req_t req, fuse_ino_t ino, size_t size,
 	    && NAttrNonResident(na)) {
 		max_read = ((na->data_size+511) & ~511) + 2;
 	}
-#endif /* HAVE_SETXATTR */
+#endif /* ENABLE_XATTR */
 	if (offset + (off_t)size > max_read) {
 		if (max_read < offset)
 			goto ok;
@@ -2483,13 +2483,13 @@ static int ntfs_fuse_create(fuse_req_t req, fuse_ino_t parent, const char *name,
 			if (fi && (ni->flags & FILE_ATTR_COMPRESSED)) {
 				state |= CLOSE_COMPRESSED;
 			}
-#ifdef HAVE_SETXATTR	/* extended attributes interface required */
+#ifdef ENABLE_XATTR	/* extended attributes interface required */
 			/* mark a future need to fixup encrypted inode */
 			if (fi
 			    && ctx->efs_raw
 			    && (ni->flags & FILE_ATTR_ENCRYPTED))
 				state |= CLOSE_ENCRYPTED;
-#endif /* HAVE_SETXATTR */
+#endif /* ENABLE_XATTR */
 			if (fi && ctx->dmtime)
 				state |= CLOSE_DMTIME;
 			ntfs_inode_update_mbsname(dir_ni, name, ni->mft_no);
@@ -3114,10 +3114,10 @@ static void ntfs_fuse_release(fuse_req_t req, fuse_ino_t ino,
 	res = 0;
 	if (of->state & CLOSE_COMPRESSED)
 		res = ntfs_attr_pclose(na);
-#ifdef HAVE_SETXATTR	/* extended attributes interface required */
+#ifdef ENABLE_XATTR	/* extended attributes interface required */
 	if (of->state & CLOSE_ENCRYPTED)
 		res = ntfs_efs_fixup_attribute(NULL, na);
-#endif /* HAVE_SETXATTR */
+#endif /* ENABLE_XATTR */
 #ifndef DISABLE_PLUGINS
 stamps :
 #endif /* DISABLE_PLUGINS */
@@ -3291,7 +3291,7 @@ done :
 		fuse_reply_bmap(req, lidx);
 }
 
-#ifdef HAVE_SETXATTR
+#ifdef ENABLE_XATTR
 
 /*
  *		  Name space identifications and prefixes
@@ -4171,7 +4171,7 @@ out :
 #if POSIXACLS
 #error "Option inconsistency : POSIXACLS requires SETXATTR"
 #endif
-#endif /* HAVE_SETXATTR */
+#endif /* ENABLE_XATTR */
 
 #ifndef DISABLE_PLUGINS
 static void register_internal_reparse_plugins(void)
@@ -4270,12 +4270,12 @@ static struct fuse_lowlevel_ops ntfs_3g_ops = {
 #if !KERNELPERMS | (POSIXACLS & !KERNELACLS)
 	.access 	= ntfs_fuse_access,
 #endif
-#ifdef HAVE_SETXATTR
+#ifdef ENABLE_XATTR
 	.getxattr	= ntfs_fuse_getxattr,
 	.setxattr	= ntfs_fuse_setxattr,
 	.removexattr	= ntfs_fuse_removexattr,
 	.listxattr	= ntfs_fuse_listxattr,
-#endif /* HAVE_SETXATTR */
+#endif /* ENABLE_XATTR */
 #if 0 && (defined(__APPLE__) || defined(__DARWIN__)) /* Unfinished. */
 	/* MacFUSE extensions. */
 	.getxtimes	= ntfs_macfuse_getxtimes,
@@ -4335,7 +4335,7 @@ static int ntfs_open(const char *device)
 		NVolSetCompression(ctx->vol);
 	else
 		NVolClearCompression(ctx->vol);
-#ifdef HAVE_SETXATTR
+#ifdef ENABLE_XATTR
 			/* archivers must see hidden files */
 	if (ctx->efs_raw)
 		ctx->hide_hid_files = FALSE;
@@ -4604,9 +4604,9 @@ int main(int argc, char *argv[])
 #endif
 	const char *permissions_mode = (const char*)NULL;
 	const char *failed_secure = (const char*)NULL;
-#if defined(HAVE_SETXATTR) && defined(XATTR_MAPPINGS)
+#if defined(ENABLE_XATTR) && defined(XATTR_MAPPINGS)
 	struct XATTRMAPPING *xattr_mapping = (struct XATTRMAPPING*)NULL;
-#endif /* defined(HAVE_SETXATTR) && defined(XATTR_MAPPINGS) */
+#endif /* defined(ENABLE_XATTR) && defined(XATTR_MAPPINGS) */
 	struct stat sbuf;
 	unsigned long existing_mount;
 	int err, fd;
@@ -4746,9 +4746,9 @@ int main(int argc, char *argv[])
 	ctx->vol->special_files = ctx->special_files;
 	ctx->security.vol = ctx->vol;
 	ctx->vol->secure_flags = ctx->secure_flags;
-#ifdef HAVE_SETXATTR	/* extended attributes interface required */
+#ifdef ENABLE_XATTR	/* extended attributes interface required */
 	ctx->vol->efs_raw = ctx->efs_raw;
-#endif /* HAVE_SETXATTR */
+#endif /* ENABLE_XATTR */
 	if (!ntfs_build_mapping(&ctx->security,ctx->usermap_path,
 		(ctx->vol->secure_flags
 			& ((1 << SECURITY_DEFAULT) | (1 << SECURITY_ACL)))
@@ -4811,7 +4811,7 @@ int main(int argc, char *argv[])
 	if (ctx->usermap_path)
 		free (ctx->usermap_path);
 
-#if defined(HAVE_SETXATTR) && defined(XATTR_MAPPINGS)
+#if defined(ENABLE_XATTR) && defined(XATTR_MAPPINGS)
 	xattr_mapping = ntfs_xattr_build_mapping(ctx->vol,
 				ctx->xattrmap_path);
 	ctx->vol->xattr_mapping = xattr_mapping;
@@ -4821,7 +4821,7 @@ int main(int argc, char *argv[])
 	 */
 	if (ctx->xattrmap_path)
 		free(ctx->xattrmap_path);
-#endif /* defined(HAVE_SETXATTR) && defined(XATTR_MAPPINGS) */
+#endif /* defined(ENABLE_XATTR) && defined(XATTR_MAPPINGS) */
 
 #ifndef DISABLE_PLUGINS
 	register_internal_reparse_plugins();
@@ -4857,9 +4857,9 @@ err_out:
 	ntfs_mount_error(opts.device, opts.mnt_point, err);
 	if (ctx->abs_mnt_point)
 		free(ctx->abs_mnt_point);
-#if defined(HAVE_SETXATTR) && defined(XATTR_MAPPINGS)
+#if defined(ENABLE_XATTR) && defined(XATTR_MAPPINGS)
 	ntfs_xattr_free_mapping(xattr_mapping);
-#endif /* defined(HAVE_SETXATTR) && defined(XATTR_MAPPINGS) */
+#endif /* defined(ENABLE_XATTR) && defined(XATTR_MAPPINGS) */
 err2:
 	ntfs_close();
 #ifndef DISABLE_PLUGINS

--- a/src/ntfs-3g.c
+++ b/src/ntfs-3g.c
@@ -184,7 +184,7 @@ static const char *usage_msg =
 "\n"
 "%s %s %s %d - Third Generation NTFS Driver\n"
 "\t\tConfiguration type %d, "
-#ifdef HAVE_SETXATTR
+#ifdef ENABLE_XATTR
 "XATTRS are on, "
 #else
 "XATTRS are off, "
@@ -391,7 +391,7 @@ static int ntfs_allowed_dir_access(struct SECURITY_CONTEXT *scx,
 
 #endif
 
-#ifdef HAVE_SETXATTR	/* extended attributes interface required */
+#ifdef ENABLE_XATTR	/* extended attributes interface required */
 
 /*
  *		Check access to parent directory
@@ -459,7 +459,7 @@ static ntfs_inode *get_parent_dir(const char *path)
 }
 
 
-#endif /* HAVE_SETXATTR */
+#endif /* ENABLE_XATTR */
 
 /**
  * ntfs_fuse_statfs - return information about mounted NTFS volume
@@ -907,7 +907,7 @@ static int ntfs_fuse_getattr(const char *org_path, struct stat *stbuf)
 		/* Regular or Interix (INTX) file. */
 		stbuf->st_mode = S_IFREG;
 		stbuf->st_size = ni->data_size;
-#ifdef HAVE_SETXATTR	/* extended attributes interface required */
+#ifdef ENABLE_XATTR	/* extended attributes interface required */
 		/*
 		 * return data size rounded to next 512 byte boundary for
 		 * encrypted files to include padding required for decryption
@@ -917,7 +917,7 @@ static int ntfs_fuse_getattr(const char *org_path, struct stat *stbuf)
 		    && (ni->flags & FILE_ATTR_ENCRYPTED)
 		    && ni->data_size)
 			stbuf->st_size = ((ni->data_size + 511) & ~511) + 2;
-#endif /* HAVE_SETXATTR */
+#endif /* ENABLE_XATTR */
 		/* 
 		 * Temporary fix to make ActiveSync work via Samba 3.0.
 		 * See more on the ntfs-3g-devel list.
@@ -947,14 +947,14 @@ static int ntfs_fuse_getattr(const char *org_path, struct stat *stbuf)
 				if (na->data_size == 1)
 					stbuf->st_mode = S_IFSOCK;
 			}
-#ifdef HAVE_SETXATTR	/* extended attributes interface required */
+#ifdef ENABLE_XATTR	/* extended attributes interface required */
 			/* encrypted named stream */
 			/* round size up to next 512 byte boundary */
 			if (ctx->efs_raw && stream_name_len && 
 			    (na->data_flags & ATTR_IS_ENCRYPTED) &&
 			    NAttrNonResident(na)) 
 				stbuf->st_size = ((na->data_size+511) & ~511)+2;
-#endif /* HAVE_SETXATTR */
+#endif /* ENABLE_XATTR */
 			/*
 			 * Check whether it's Interix symbolic link, block or
 			 * character device.
@@ -1527,13 +1527,13 @@ static int ntfs_fuse_open(const char *org_path,
 		/* mark a future need to compress the last chunk */
 			if (na->data_flags & ATTR_COMPRESSION_MASK)
 				fi->fh |= CLOSE_COMPRESSED;
-#ifdef HAVE_SETXATTR	/* extended attributes interface required */
+#ifdef ENABLE_XATTR	/* extended attributes interface required */
 			/* mark a future need to fixup encrypted inode */
 			if (ctx->efs_raw
 			    && !(na->data_flags & ATTR_IS_ENCRYPTED)
 			    && (ni->flags & FILE_ATTR_ENCRYPTED))
 				fi->fh |= CLOSE_ENCRYPTED;
-#endif /* HAVE_SETXATTR */
+#endif /* ENABLE_XATTR */
 		/* mark a future need to update the mtime */
 			if (ctx->dmtime)
 				fi->fh |= CLOSE_DMTIME;
@@ -1599,7 +1599,7 @@ static int ntfs_fuse_read(const char *org_path, char *buf, size_t size,
 		goto exit;
 	}
 	max_read = na->data_size;
-#ifdef HAVE_SETXATTR	/* extended attributes interface required */
+#ifdef ENABLE_XATTR	/* extended attributes interface required */
 	/* limit reads at next 512 byte boundary for encrypted attributes */
 	if (ctx->efs_raw
 	    && max_read
@@ -1607,7 +1607,7 @@ static int ntfs_fuse_read(const char *org_path, char *buf, size_t size,
 	    && NAttrNonResident(na)) {
 		max_read = ((na->data_size+511) & ~511) + 2;
 	}
-#endif /* HAVE_SETXATTR */
+#endif /* ENABLE_XATTR */
 	if (offset + (off_t)size > max_read) {
 		if (max_read < offset)
 			goto ok;
@@ -1776,10 +1776,10 @@ static int ntfs_fuse_release(const char *org_path,
 	res = 0;
 	if (fi->fh & CLOSE_COMPRESSED)
 		res = ntfs_attr_pclose(na);
-#ifdef HAVE_SETXATTR	/* extended attributes interface required */
+#ifdef ENABLE_XATTR	/* extended attributes interface required */
 	if (fi->fh & CLOSE_ENCRYPTED)
 		res = ntfs_efs_fixup_attribute(NULL, na);
-#endif /* HAVE_SETXATTR */
+#endif /* ENABLE_XATTR */
 #ifndef DISABLE_PLUGINS
 stamps:
 #endif /* DISABLE_PLUGINS */
@@ -2212,13 +2212,13 @@ static int ntfs_fuse_create(const char *org_path, mode_t typemode, dev_t dev,
 			if (fi && (ni->flags & FILE_ATTR_COMPRESSED)) {
 				fi->fh |= CLOSE_COMPRESSED;
 			}
-#ifdef HAVE_SETXATTR	/* extended attributes interface required */
+#ifdef ENABLE_XATTR	/* extended attributes interface required */
 			/* mark a future need to fixup encrypted inode */
 			if (fi
 			    && ctx->efs_raw
 			    && (ni->flags & FILE_ATTR_ENCRYPTED))
 				fi->fh |= CLOSE_ENCRYPTED;
-#endif /* HAVE_SETXATTR */
+#endif /* ENABLE_XATTR */
 			/* mark a need to update the mtime */
 			if (fi && ctx->dmtime)
 				fi->fh |= CLOSE_DMTIME;
@@ -2285,12 +2285,12 @@ static int ntfs_fuse_create_stream(const char *path,
 		/* mark a future need to compress the last block */
 		if (ni->flags & FILE_ATTR_COMPRESSED)
 			fi->fh |= CLOSE_COMPRESSED;
-#ifdef HAVE_SETXATTR	/* extended attributes interface required */
+#ifdef ENABLE_XATTR	/* extended attributes interface required */
 		/* mark a future need to fixup encrypted inode */
 		if (ctx->efs_raw
 		    && (ni->flags & FILE_ATTR_ENCRYPTED))
 			fi->fh |= CLOSE_ENCRYPTED;
-#endif /* HAVE_SETXATTR */
+#endif /* ENABLE_XATTR */
 		if (ctx->dmtime)
 			fi->fh |= CLOSE_DMTIME;
 	}
@@ -2991,7 +2991,7 @@ close_inode:
 	return ret;
 }
 
-#ifdef HAVE_SETXATTR
+#ifdef ENABLE_XATTR
 
 /*
  *                Name space identifications and prefixes
@@ -3871,7 +3871,7 @@ exit:
 #if POSIXACLS
 #error "Option inconsistency : POSIXACLS requires SETXATTR"
 #endif
-#endif /* HAVE_SETXATTR */
+#endif /* ENABLE_XATTR */
 
 #ifndef DISABLE_PLUGINS
 static void register_internal_reparse_plugins(void)
@@ -3983,12 +3983,12 @@ static struct fuse_operations ntfs_3g_ops = {
 	.opendir	= ntfs_fuse_opendir,
 	.releasedir	= ntfs_fuse_release,
 #endif
-#ifdef HAVE_SETXATTR
+#ifdef ENABLE_XATTR
 	.getxattr	= ntfs_fuse_getxattr,
 	.setxattr	= ntfs_fuse_setxattr,
 	.removexattr	= ntfs_fuse_removexattr,
 	.listxattr	= ntfs_fuse_listxattr,
-#endif /* HAVE_SETXATTR */
+#endif /* ENABLE_XATTR */
 #if defined(__APPLE__) || defined(__DARWIN__)
 	/* MacFUSE extensions. */
 	.getxtimes	= ntfs_macfuse_getxtimes,
@@ -4047,7 +4047,7 @@ static int ntfs_open(const char *device)
 		NVolSetCompression(ctx->vol);
 	else
 		NVolClearCompression(ctx->vol);
-#ifdef HAVE_SETXATTR
+#ifdef ENABLE_XATTR
 			/* archivers must see hidden files */
 	if (ctx->efs_raw)
 		ctx->hide_hid_files = FALSE;
@@ -4332,9 +4332,9 @@ int main(int argc, char *argv[])
 #endif
 	const char *permissions_mode = (const char*)NULL;
 	const char *failed_secure = (const char*)NULL;
-#if defined(HAVE_SETXATTR) && defined(XATTR_MAPPINGS)
+#if defined(ENABLE_XATTR) && defined(XATTR_MAPPINGS)
 	struct XATTRMAPPING *xattr_mapping = (struct XATTRMAPPING*)NULL;
-#endif /* defined(HAVE_SETXATTR) && defined(XATTR_MAPPINGS) */
+#endif /* defined(ENABLE_XATTR) && defined(XATTR_MAPPINGS) */
 	struct stat sbuf;
 	unsigned long existing_mount;
 	int err, fd;
@@ -4474,9 +4474,9 @@ int main(int argc, char *argv[])
 	ctx->security.vol = ctx->vol;
 	ctx->vol->secure_flags = ctx->secure_flags;
 	ctx->vol->special_files = ctx->special_files;
-#ifdef HAVE_SETXATTR	/* extended attributes interface required */
+#ifdef ENABLE_XATTR	/* extended attributes interface required */
 	ctx->vol->efs_raw = ctx->efs_raw;
-#endif /* HAVE_SETXATTR */
+#endif /* ENABLE_XATTR */
 	if (!ntfs_build_mapping(&ctx->security,ctx->usermap_path,
 		(ctx->vol->secure_flags
 			& ((1 << SECURITY_DEFAULT) | (1 << SECURITY_ACL)))
@@ -4538,7 +4538,7 @@ int main(int argc, char *argv[])
 	if (ctx->usermap_path)
 		free (ctx->usermap_path);
 
-#if defined(HAVE_SETXATTR) && defined(XATTR_MAPPINGS)
+#if defined(ENABLE_XATTR) && defined(XATTR_MAPPINGS)
 	xattr_mapping = ntfs_xattr_build_mapping(ctx->vol,
 				ctx->xattrmap_path);
 	ctx->vol->xattr_mapping = xattr_mapping;
@@ -4548,7 +4548,7 @@ int main(int argc, char *argv[])
 	 */
 	if (ctx->xattrmap_path)
 		free(ctx->xattrmap_path);
-#endif /* defined(HAVE_SETXATTR) && defined(XATTR_MAPPINGS) */
+#endif /* defined(ENABLE_XATTR) && defined(XATTR_MAPPINGS) */
 
 #ifndef DISABLE_PLUGINS
 	register_internal_reparse_plugins();
@@ -4586,9 +4586,9 @@ err_out:
 	ntfs_mount_error(opts.device, opts.mnt_point, err);
 	if (ctx->abs_mnt_point)
 		free(ctx->abs_mnt_point);
-#if defined(HAVE_SETXATTR) && defined(XATTR_MAPPINGS)
+#if defined(ENABLE_XATTR) && defined(XATTR_MAPPINGS)
 	ntfs_xattr_free_mapping(xattr_mapping);
-#endif /* defined(HAVE_SETXATTR) && defined(XATTR_MAPPINGS) */
+#endif /* defined(ENABLE_XATTR) && defined(XATTR_MAPPINGS) */
 err2:
 	ntfs_close();
 #ifndef DISABLE_PLUGINS

--- a/src/ntfs-3g_common.c
+++ b/src/ntfs-3g_common.c
@@ -250,9 +250,9 @@ char *parse_mount_options(ntfs_fuse_context_t *ctx,
 	const struct DEFOPTION *poptl;
 
 	ctx->secure_flags = 0;
-#ifdef HAVE_SETXATTR	/* extended attributes interface required */
+#ifdef ENABLE_XATTR	/* extended attributes interface required */
 	ctx->efs_raw = FALSE;
-#endif /* HAVE_SETXATTR */
+#endif /* ENABLE_XATTR */
 	ctx->compression = DEFAULT_COMPRESSION;
 	options = strdup(orig_opts ? orig_opts : "");
 	if (!options) {
@@ -490,7 +490,7 @@ char *parse_mount_options(ntfs_fuse_context_t *ctx,
 					goto err_exit;
 				}
 				break;
-#ifdef HAVE_SETXATTR	/* extended attributes interface required */
+#ifdef ENABLE_XATTR	/* extended attributes interface required */
 #ifdef XATTR_MAPPINGS
 			case OPT_XATTRMAPPING :
 				ctx->xattrmap_path = strdup(val);
@@ -504,7 +504,7 @@ char *parse_mount_options(ntfs_fuse_context_t *ctx,
 			case OPT_EFS_RAW :
 				ctx->efs_raw = TRUE;
 				break;
-#endif /* HAVE_SETXATTR */
+#endif /* ENABLE_XATTR */
 			case OPT_POSIX_NLINK :
 				ctx->posix_nlink = TRUE;
 				break;
@@ -685,7 +685,7 @@ int ntfs_parse_options(struct ntfs_options *popts, void (*usage)(void),
 	return 0;
 }
 
-#ifdef HAVE_SETXATTR
+#ifdef ENABLE_XATTR
 
 int ntfs_fuse_listxattr_common(ntfs_inode *ni, ntfs_attr_search_ctx *actx,
 			char *list, size_t size, BOOL prefixing)
@@ -791,7 +791,7 @@ exit :
 	return (ret);
 }
 
-#endif /* HAVE_SETXATTR */
+#endif /* ENABLE_XATTR */
 
 #ifndef DISABLE_PLUGINS
 
@@ -903,7 +903,7 @@ void close_reparse_plugins(ntfs_fuse_context_t *ctx)
 
 #endif /* DISABLE_PLUGINS */
 
-#ifdef HAVE_SETXATTR
+#ifdef ENABLE_XATTR
 
 /*
  *		Check whether a user xattr is allowed
@@ -959,4 +959,4 @@ BOOL user_xattrs_allowed(ntfs_fuse_context_t *ctx __attribute__((unused)),
 	return (res);
 }
 
-#endif /* HAVE_SETXATTR */
+#endif /* ENABLE_XATTR */

--- a/src/ntfs-3g_common.h
+++ b/src/ntfs-3g_common.h
@@ -159,12 +159,12 @@ typedef struct {
 	BOOL mounted;
 	BOOL posix_nlink;
 	ntfs_volume_special_files special_files;
-#ifdef HAVE_SETXATTR	/* extended attributes interface required */
+#ifdef ENABLE_XATTR	/* extended attributes interface required */
 	BOOL efs_raw;
 #ifdef XATTR_MAPPINGS
 	char *xattrmap_path;
 #endif /* XATTR_MAPPINGS */
-#endif /* HAVE_SETXATTR */
+#endif /* ENABLE_XATTR */
 	struct fuse_chan *fc;
 	BOOL inherit;
 	unsigned int secure_flags;


### PR DESCRIPTION
There is for issue https://github.com/tuxera/ntfs-3g/issues/174
FreeBSD has a separate API for accessing extended attributes.: https://man.freebsd.org/cgi/man.cgi?request=extattr_set_file&sektion=2&n=1
The configuration only checks setxattr, which is not available on FreeBSD.
So, this PR changes:
1. if **setxattr** or **extattr_set_file** is available, then the **ENABLE_XATTR** variable is defined.
2. The macros for using **HAVE_SETXATTR** have been changed to **ENABLE_XATTR** in the code.

After this patch, xattr will be available on Linux and FreeBSD:
```
# ./configure  --exec-prefix=/ --disable-mount-helper  --disable-mtab --with-fuse=external --disable-ldconfig
.....
checking for setxattr... no
checking for extattr_set_file... yes
.....
# LD_LIBRARY_PATH=$(pwd)/libntfs-3g/.libs  ./src/.libs/ntfs-3g -h
ntfs-3g 2022.10.3 external FUSE 29 - Third Generation NTFS Driver
		Configuration type 1, XATTRS are on, POSIX ACLS are off
# LD_LIBRARY_PATH=$(pwd)/libntfs-3g/.libs  ./src/.libs/ntfs-3g -o debug, rotest_ntfs.img  /tmp/fs
# getextattr -h -x  system ntfs_acl /tmp/fs/Users
/tmp/fs/Users	01 00 14 90 a0 00 00 00 b0 00 00 00 00 00 00 00 14 00 00 00 02 00 8c 00 06 00 00 00 00 03 14 00 ff 01 1f 00 01 01 00 00 00 00 00 05 12 00 00 00 00 03 18 00 ff 01 1f 00 01 02 00 00 00 00 00 05 20 00 00 00 20 02 00 00 00 00 18 00 a9 00 12 00 01 02 00 00 00 00 00 05 20 00 00 00 21 02 00 00 00 0b 18 00 00 00 00 a0 01 02 00 00 00 00 00 05 20 00 00 00 21 02 00 00 00 00 14 00 a9 00 12 00 01 01 00 00 00 00 00 01 00 00 00 00 00 0b 14 00 00 00 00 a0 01 01 00 00 00 00 00 01 00 00 00 00 01 02 00 00 00 00 00 05 20 00 00 00 20 02 00 00 01 02 00 00 00 00 00 05 20 00 00 00 20 02 00 00

unique: 2, opcode: ACCESS (34), nodeid: 1, insize: 48, pid: 46841
   unique: 2, error: -78 (Function not implemented), outsize: 16
unique: 3, opcode: LOOKUP (1), nodeid: 1, insize: 46, pid: 46841
LOOKUP /Users
getattr /Users
   NODEID: 2
   unique: 3, success, outsize: 144
unique: 4, opcode: GETXATTR (22), nodeid: 2, insize: 64, pid: 46841
getxattr /Users system.ntfs_acl 0
   unique: 4, success, outsize: 24
unique: 5, opcode: GETXATTR (22), nodeid: 2, insize: 64, pid: 46841
getxattr /Users system.ntfs_acl 192
   unique: 5, success, outsize: 208
```